### PR TITLE
Update README for copy-pasteable example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You have three different ways to build an OBB: using a covariance matrix, using 
 
 For instance, you can create an OBB from the points of a lat/lon sphere
 
-    from math import pi, cos, sin
+    from math import pi, cos, sin, sqrt
     from pyobb.obb import OBB
     
     # creates a lat/lon sphere with a given radius and centered at a given point


### PR DESCRIPTION
The first example code snippet in the README file also requires `sqrt` imported from the math library. Adding this in means the code snippet can be copy-pasted and run immediately.